### PR TITLE
Ensure ~/.local/share/themes is created before doing a local install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,7 @@ elif [ "$UID" -ne "$ROOT_UID" ]; then
 		    ;;
 		esac
 	fi
+	mkdir -p $HOME/.local/share/themes
 	cp -R ./Paper/ $HOME/.local/share/themes/
 	echo "Installation complete!"
 fi


### PR DESCRIPTION
There are some situations whereby this directory does not exist:
- user has not installed a theme to their home directory before
- user previously used ~/.themes for local installations

In that case, if the directory is not created prior to copying the Paper
directory, the content of the Paper directory ends up in ~/.local/share/themes,
instead of the directory itself.

Note that the installer would have failed with an error if ~/.local/share does not exist, but this is rather unlikely. Creating the directory with mkdir -p fixes both failure modes.