### PR TITLE
Added color to `gnome-system-moniter`'s headerbar

### DIFF
--- a/Paper/gtk-3.0/apps.css
+++ b/Paper/gtk-3.0/apps.css
@@ -40,6 +40,7 @@
 /*@import url("apps/gnome-music.css");*/
 @import url("apps/gnome-photos.css");
 /*@import url("apps/gnome-software.css");*/
+@import url("apps/gnome-system-monitor.css");
 @import url("apps/gnome-terminal.css");
 @import url("apps/gnome-tweak-tool.css");
 @import url("apps/gnome.css");

--- a/Paper/gtk-3.0/apps/gnome-system-monitor.css
+++ b/Paper/gtk-3.0/apps/gnome-system-monitor.css
@@ -1,0 +1,33 @@
+/* Copyright 2015 Sam Hewitt.
+*
+* This file is part of the Paper GTK theme.
+*
+* The Paper GTK theme is free software: you can redistribute it
+* and/or modify it under the terms of the GNU General Public License as
+* published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* The Paper GTK theme is distributed in the hope that it will be
+* useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+* Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with the Paper GTK theme. If not, see http://www.gnu.org/licenses/.
+*/
+
+@define-color gnome-system-monitor #6fbe72;
+
+/**********
+ * Header *
+ **********/
+
+#gnome-system-monitor .titlebar,
+#gnome-system-monitor .header-bar {
+    background-color: @gnome-system-monitor;
+}
+
+#gnome-system-monitor .titlebar:backdrop,
+#gnome-system-monitor .header-bar:backdrop {
+    background-color: shade(@gnome-system-monitor,0.9);
+}


### PR DESCRIPTION
Added one file and included it from `apps.css`.  The color is `#6fbe72`, taken from the graph line on the Paper Icon theme.