### PR TITLE
Gives Geary a lovely yellow titlebar!

### DIFF
--- a/Paper/gtk-3.0/apps/geary.css
+++ b/Paper/gtk-3.0/apps/geary.css
@@ -16,7 +16,7 @@
 * with the Paper GTK theme. If not, see http://www.gnu.org/licenses/.
 */
 
-@define-color geary #FCBE2D;
+@define-color geary #fec006;
 
 /**********
  * Header *

--- a/Paper/gtk-3.0/apps/geary.css
+++ b/Paper/gtk-3.0/apps/geary.css
@@ -16,7 +16,7 @@
 * with the Paper GTK theme. If not, see http://www.gnu.org/licenses/.
 */
 
-@define-color geary #FECD38;
+@define-color geary #FCBE2D;
 
 /**********
  * Header *

--- a/Paper/gtk-3.0/apps/geary.css
+++ b/Paper/gtk-3.0/apps/geary.css
@@ -16,7 +16,21 @@
 * with the Paper GTK theme. If not, see http://www.gnu.org/licenses/.
 */
 
-/*@define-color geary #ebdd4d;*/
+@define-color geary #FECD38;
+
+/**********
+ * Header *
+ **********/
+
+.geary-titlebar-left, .geary-titlebar-right {
+    background-color: @geary;
+}
+
+.geary-titlebar-left .separator { opacity: 0; }
+
+.geary-titlebar-left:backdrop, .geary-titlebar-right:backdrop {
+    background-color: shade(@geary, 0.9);
+}
 
 /*********************
  * Conversation View *


### PR DESCRIPTION


I found a way to uniquely target Geary's headerbar so we can give it a nice yellow color and allow it to join gEdit and Web in the ranks of GTK3 awesomeness.  The color is from your Paper icon theme so it blends in perfectly.

![screenshot_2](https://cloud.githubusercontent.com/assets/7308014/7828281/b9b5b73c-03ee-11e5-9fed-f2a2506d09f8.png)
