### PR TITLE
Remove 1px line at the top in Totem when in fullscreen mode

### DIFF
--- a/Paper/gtk-3.0/apps/gnome.css
+++ b/Paper/gtk-3.0/apps/gnome.css
@@ -56,6 +56,13 @@ GucharmapChartable:selected {
     color: @selected_foreground;
 }
 
+/*********
+ * Totem *
+ *********/
+/* removes the 1px line at the top of the screen when in fullscreen mode */
+GtkApplicationWindow > GtkVBox > GtkStack > GtkVBox > GtkOverlay > GtkRevealer {
+    background-color: black;
+}
 
 /**************
  * GNOME Misc *


### PR DESCRIPTION
Watching movies with Totem in fullscreen mode you see a small 1px line at the top of the screen which can be quite distracting, especially when the movie has dark background colours. I came up with a dirty but simple fix which changes the background colour of the revealer widget to black (see the code). There is probably a better solution for this but until now I couldn´t find any.

Original look:
![gnome-video-bug](https://cloud.githubusercontent.com/assets/4512073/8781916/6cd59406-2f12-11e5-8ec8-0a0f7594257f.png)
With fix applied:
![gnome-video-fixed](https://cloud.githubusercontent.com/assets/4512073/8781927/7d64ee70-2f12-11e5-9bbd-96c6e555c66b.png)
You have to open the images in a new tab to see the line!
