### PR TITLE
removed CSS rule to prevent shrinking of gnome-terminal

### DIFF
--- a/Paper/gtk-3.0/widgets/notebook.css
+++ b/Paper/gtk-3.0/widgets/notebook.css
@@ -291,7 +291,6 @@
 .notebook tab .button:active,
 .notebook tab .button:hover {
     color: @backdrop_text;
-    border: none;
     background-image: none;
     background: none;
     border-radius: 4px;


### PR DESCRIPTION
According to #66, the gnome-terminal shrinks if focus is lost. This occurs only if there are at least 2 tabs open. By removing the CSS rule `border: none;` from `notebook-tab.button`, the problem seems to be resolved. I never noticed unwanted side-effects. 