### PR TITLE
min width for .panel-button elements because of cropped images

### DIFF
--- a/Paper/gnome-shell/gnome-shell.css
+++ b/Paper/gnome-shell/gnome-shell.css
@@ -601,7 +601,7 @@ StScrollBar {
   #panel .panel-button {
     -natural-hpadding: 12px;
     -minimum-hpadding: 6px;
-    min-width; 45px;
+    min-width: 45px;
     font-weight: bold;
     color: #ccc;
     transition-duration: 100ms; }

--- a/Paper/gnome-shell/gnome-shell.css
+++ b/Paper/gnome-shell/gnome-shell.css
@@ -601,6 +601,7 @@ StScrollBar {
   #panel .panel-button {
     -natural-hpadding: 12px;
     -minimum-hpadding: 6px;
+    min-width; 45px;
     font-weight: bold;
     color: #ccc;
     transition-duration: 100ms; }


### PR DESCRIPTION
Should fix snwh/paper-gtk-theme#239

I honestly don't know how the change in the last line was created. I used vim and don't see it in my local file.