### PR TITLE
install.sh: Use install -d

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -84,19 +84,11 @@ elif [ "$UID" -ne "$ROOT_UID" ]; then
 	fi
 	echo "Installing..."
 	# .local/share/themes
-	if [ -d $HOME/.local/share/themes ]; then
-		cp -R ./Paper/ $HOME/.local/share/themes/
-	else
-		mkdir -p $HOME/.local/share/themes
-		cp -R ./Paper/ $HOME/.local/share/themes/
-	fi
+    install -d $HOME/.local/share/themes
+	cp -R ./Paper/ $HOME/.local/share/themes/
 	# .themes
-	if [ -d $HOME/.themes ]; then
-		cp -R ./Paper/ $HOME/.themes/
-	else
-		mkdir -p $HOME/.themes
-		cp -R ./Paper/ $HOME/.themes/
-	fi
+    install -d $HOME/.themes
+	cp -R ./Paper/ $HOME/.themes/
 	echo "Installation complete!"
 	set
 fi


### PR DESCRIPTION
Instead of checking for the existence of a directory, and repeating the same code in both branches (with an mkdir added in the else branch), use install -d to create the directory if it does not exist.

This simplifies the code a little, by removing a bit of repetition.
