### PR TITLE
Fix loading spinner in the top bar

### DIFF
--- a/Paper/gnome-shell/gnome-shell.css
+++ b/Paper/gnome-shell/gnome-shell.css
@@ -846,7 +846,8 @@ StScrollBar {
   border: none; }
 
 #appMenu {
-  spinner-image: url("assets/process-working.svg");
+  /*spinner-image: url("assets/process-working.svg"); Broken, not compatible with 60 fps. See https://github.com/theRealPadster/Mist-theme/issues/4 */
+  spinner-image:  url("resource:///org/gnome/shell/theme/process-working.svg");
   spacing: 4px; }
   #appMenu .label-shadow {
     color: transparent; }


### PR DESCRIPTION
Fixes issue https://github.com/snwh/paper-gtk-theme/issues/260

It will replace the current spinner with the default gnome-shell one as the current spinner format does not have enough animation steps.
It currently has 8, probably needs 60 as that's the amount of steps the default spinner has.

Similar issue here: https://github.com/theRealPadster/Mist-theme/issues/4