### PR TITLE
Calendar fix for #263, partial fix for #223

### DIFF
--- a/Paper/gtk-3.0/gtk.css
+++ b/Paper/gtk-3.0/gtk.css
@@ -42,6 +42,15 @@
 @define-color highlight alpha(#fff, 0.2);
 @define-color shadow alpha(#000, 0.2);
 
+/* Fixes for 263, and partial fix for 223 (gnome-calendar)
+ * https://github.com/snwh/paper-gtk-theme/issues/223 *
+ * https://github.com/snwh/paper-gtk-theme/issues/263 */
+@define-color theme_fg_color @foreground;
+@define-color theme_bg_color @background;
+@define-color theme_text_color @text;
+@define-color theme_base_color @base;
+@define-color borders @border;
+
 
 /***********
  * Imports *


### PR DESCRIPTION
Appears that gtk-themes have some names that are expected. "theme_fg_color" is used specifically by gnome-calendar. Without it, text was invisible (#223, #263). I've added a similar aliases as well.

Note that this does not completely fix #223, as month labels are still missing.

A more complete solution may be to switch all the old references ("@foreground", etc) to the new ones ("@theme_fg_color", etc). However, I'm unsure if the existing values are referenced by applications directly, so I opted for keeping both.