### PR TITLE
"Fix" broken overflow

### DIFF
--- a/Paper/gtk-3.0/gtk-widgets.css
+++ b/Paper/gtk-3.0/gtk-widgets.css
@@ -79,7 +79,7 @@
 @import url("widgets/miscellaneous.css");
 @import url("widgets/notebook.css");
 @import url("widgets/osd.css");
-/*@import url("widgets/overflow.css");*/
+@import url("widgets/overflow.css");
 @import url("widgets/popovers.css");
 @import url("widgets/progressbars.css");
 @import url("widgets/scales.css");


### PR DESCRIPTION
The overflow's CSS has been commented out, resulting in ugly white boxes.
This partially reverts commit 4cd6bdc4d4.