### PR TITLE
Fix for https://github.com/snwh/paper-gtk-theme/issues/319 following the suggestion of @poltertec.

### DIFF
--- a/Paper/gtk-3.18/gtk-dark.css
+++ b/Paper/gtk-3.18/gtk-dark.css
@@ -2447,10 +2447,8 @@ GraniteWidgetsWelcome {
 .header-bar {
   padding: 0 8px;
   border: none;
-  border-radius: 4px 4px 0 0;
   background-color: #303f46;
-  color: rgba(255, 255, 255, 0.8);
-  box-shadow: inset 0 1px rgba(255, 255, 255, 0.1); }
+  color: rgba(255, 255, 255, 0.8); }
   .titlebar:backdrop:not(headerbar),
   .header-bar:backdrop {
     background-color: #303f46;
@@ -2793,9 +2791,9 @@ GraniteWidgetsWelcome {
     color: transparent;
     background-color: transparent; }
 
-.titlebar, .titlebar:backdrop {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px; }
+.titlebar {
+  border-radius: 4px 4px 0 0;
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.1); }
 
 .separator:first-child + .header-bar, .separator:first-child + .header-bar:backdrop, separator:first-child + .header-bar, separator:first-child + .header-bar:backdrop, .header-bar:first-child, .header-bar:first-child:backdrop {
   border-top-left-radius: 4px; }

--- a/Paper/gtk-3.18/gtk.css
+++ b/Paper/gtk-3.18/gtk.css
@@ -2456,10 +2456,8 @@ GraniteWidgetsWelcome {
 .header-bar {
   padding: 0 8px;
   border: none;
-  border-radius: 4px 4px 0 0;
   background-color: #546e7a;
-  color: #ffffff;
-  box-shadow: inset 0 1px rgba(255, 255, 255, 0.2); }
+  color: #ffffff; }
   .titlebar:backdrop:not(headerbar),
   .header-bar:backdrop {
     background-color: #546e7a;
@@ -2802,9 +2800,9 @@ GraniteWidgetsWelcome {
     color: transparent;
     background-color: transparent; }
 
-.titlebar, .titlebar:backdrop {
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px; }
+.titlebar {
+  border-radius: 4px 4px 0 0;
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.2); }
 
 .separator:first-child + .header-bar, .separator:first-child + .header-bar:backdrop, separator:first-child + .header-bar, separator:first-child + .header-bar:backdrop, .header-bar:first-child, .header-bar:first-child:backdrop {
   border-top-left-radius: 4px; }

--- a/Paper/gtk-3.18/widgets/_header-bars.scss
+++ b/Paper/gtk-3.18/widgets/_header-bars.scss
@@ -6,12 +6,9 @@
 .header-bar {
   padding:0 8px;
   border: none;
-  border-radius: 4px 4px 0 0;
 
   background-color: $headerbar_bg_color;
   color: $headerbar_fg_color;
-
-  box-shadow: inset 0 1px $top_highlight;
 
   &:backdrop {
     background-color: $headerbar_bg_color;
@@ -396,11 +393,9 @@
 }
 
 .titlebar {
-  &, &:backdrop {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-  }
-}
+   border-radius: 4px 4px 0 0;
+   box-shadow: inset 0 1px $top_highlight;
+ }
 
 .header-bar {
   .separator:first-child + &,


### PR DESCRIPTION
With these changes, the e.g. Nautilus window looks like this:
![schermata del 2016-08-22 10-36-22 - edited](https://cloud.githubusercontent.com/assets/4618521/17848765/96716ac4-6855-11e6-8d4b-f44842be6473.png)
(just for comparison with the first image in issue  https://github.com/snwh/paper-gtk-theme/issues/319).