### PR TITLE
Fix #355: Text not readable on error in entry (fg==bg)

### DIFF
--- a/Paper/gtk-3.20/gtk-dark.css
+++ b/Paper/gtk-3.20/gtk-dark.css
@@ -2269,7 +2269,7 @@ entry {
     box-shadow: none; }
   spinbutton.error:not(.vertical), GeditWindow > .error.entry,
   entry.error {
-    color: #d32f2f;
+    color: #ffffff;
     border-color: #420e0e; }
     spinbutton.error:focus:not(.vertical), GeditWindow > .error.entry:focus,
     entry.error:focus {
@@ -2281,7 +2281,7 @@ entry {
       background-color: #d32f2f; }
   spinbutton.warning:not(.vertical), GeditWindow > .warning.entry,
   entry.warning {
-    color: #f9ce1d;
+    color: #ffffff;
     border-color: #614e03; }
     spinbutton.warning:focus:not(.vertical), GeditWindow > .warning.entry:focus,
     entry.warning:focus {

--- a/Paper/gtk-3.20/gtk.css
+++ b/Paper/gtk-3.20/gtk.css
@@ -2278,7 +2278,7 @@ entry {
     box-shadow: none; }
   spinbutton.error:not(.vertical), GeditWindow > .error.entry,
   entry.error {
-    color: #d32f2f;
+    color: #ffffff;
     border-color: #d32f2f; }
     spinbutton.error:focus:not(.vertical), GeditWindow > .error.entry:focus,
     entry.error:focus {
@@ -2290,7 +2290,7 @@ entry {
       background-color: #d32f2f; }
   spinbutton.warning:not(.vertical), GeditWindow > .warning.entry,
   entry.warning {
-    color: #f9ce1d;
+    color: #ffffff;
     border-color: #f9ce1d; }
     spinbutton.warning:focus:not(.vertical), GeditWindow > .warning.entry:focus,
     entry.warning:focus {

--- a/Paper/gtk-3.20/widgets/_entries.scss
+++ b/Paper/gtk-3.20/widgets/_entries.scss
@@ -52,7 +52,12 @@ entry {
     @each $e_type, $e_color in (error, $error_color),
                                (warning, $warning_color) {
       &.#{$e_type} {
-        color: $e_color;
+        // TODO consider using https://gist.github.com/jlong/f06f5843104ee10006fe for better color determination
+        @if (lightness($e_color) > 60) {
+          color: #000000;
+        } @else {
+          color: #ffffff;
+        }
         border-color: entry_focus_border($e_color);
 
         &:focus { @include entry(focus, $e_color); }


### PR DESCRIPTION
Fg/bg colors should be different in entries (i.e. search entry in gedit).

To make the text readable, the fg color is dynamically set using this approach:
http://thesassway.com/intermediate/dynamically-change-text-color-based-on-its-background-with-sass

Consider using the approach given at https://gist.github.com/jlong/f06f5843104ee10006fe
which promises even better fg color determination.

Resolves: #355, #383