### PR TITLE
remove label selector to prevent white-on-white in lite theme

### DIFF
--- a/Paper/gtk-3.20/widgets/_header-bars.scss
+++ b/Paper/gtk-3.20/widgets/_header-bars.scss
@@ -228,7 +228,6 @@ headerbar {
       }
     }
 
-    label,
     image {
       color: $headerbar_fg_color;
 


### PR DESCRIPTION
#385 